### PR TITLE
fix close after bad request

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -139,7 +139,6 @@ class SimplyImitatedSQSHttpServer {
           response.end(this[params.Action](params))
         } catch (e) {
           response.end('error')
-          this.close()
         }
       })
     })


### PR DESCRIPTION
If the client issues a bad request the server shouldn't shut down and still be available.